### PR TITLE
Added new endpoints to set resolution and finish launch

### DIFF
--- a/Delta Reporter.postman_collection.json
+++ b/Delta Reporter.postman_collection.json
@@ -11,12 +11,11 @@
 				"method": "POST",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:5001/api/v1/initial_setup",
-					"protocol": "http",
+					"raw": "localhost:5000/api/v1/initial_setup",
 					"host": [
 						"localhost"
 					],
-					"port": "5001",
+					"port": "5000",
 					"path": [
 						"api",
 						"v1",
@@ -40,7 +39,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"name\": \"Delta Reporter\",\n    \"data\": {\n        \"url\": \"www.deltareporter.com\"\n    },\n    \"project_status_id\": 1\n}",
+					"raw": "{\n    \"name\": \"DoneDeal\",\n    \"project_status_id\": 1\n} ",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -48,12 +47,12 @@
 					}
 				},
 				"url": {
-					"raw": "http://localhost:5001/api/v1/project",
+					"raw": "http://localhost:5000/api/v1/project",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "5001",
+					"port": "5000",
 					"path": [
 						"api",
 						"v1",
@@ -69,12 +68,12 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:5001/api/v1/project/1",
+					"raw": "http://localhost:5000/api/v1/project/1",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "5001",
+					"port": "5000",
 					"path": [
 						"api",
 						"v1",
@@ -91,12 +90,12 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:5001/api/v1/projects",
+					"raw": "http://localhost:5000/api/v1/projects",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "5001",
+					"port": "5000",
 					"path": [
 						"api",
 						"v1",
@@ -128,12 +127,12 @@
 					}
 				},
 				"url": {
-					"raw": "http://localhost:5001/api/v1/launch",
+					"raw": "http://localhost:5000/api/v1/launch",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "5001",
+					"port": "5000",
 					"path": [
 						"api",
 						"v1",
@@ -149,12 +148,12 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:5001/api/v1/launch/1",
+					"raw": "http://localhost:5000/api/v1/launch/1",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "5001",
+					"port": "5000",
 					"path": [
 						"api",
 						"v1",
@@ -171,12 +170,12 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:5001/api/v1/launch/project/1",
+					"raw": "http://localhost:5000/api/v1/launch/project/1",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "5001",
+					"port": "5000",
 					"path": [
 						"api",
 						"v1",
@@ -189,21 +188,30 @@
 			"response": []
 		},
 		{
-			"name": "Get Launches",
+			"name": "Finish Launch",
 			"request": {
-				"method": "GET",
+				"method": "PUT",
 				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"launch_id\": 2\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
 				"url": {
-					"raw": "http://localhost:5001/api/v1/launches",
+					"raw": "http://localhost:5000/api/v1/finish_launch",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "5001",
+					"port": "5000",
 					"path": [
 						"api",
 						"v1",
-						"launches"
+						"finish_launch"
 					]
 				}
 			},
@@ -231,12 +239,12 @@
 					}
 				},
 				"url": {
-					"raw": "http://localhost:5001/api/v1/test_run",
+					"raw": "http://localhost:5000/api/v1/test_run",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "5001",
+					"port": "5000",
 					"path": [
 						"api",
 						"v1",
@@ -252,17 +260,17 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:5001/api/v1/test_run/3",
+					"raw": "http://localhost:5000/api/v1/test_run/1",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "5001",
+					"port": "5000",
 					"path": [
 						"api",
 						"v1",
 						"test_run",
-						"3"
+						"1"
 					]
 				}
 			},
@@ -274,39 +282,18 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:5001/api/v1/test_run/launch/20",
+					"raw": "http://localhost:5000/api/v1/test_run/launch/1",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "5001",
+					"port": "5000",
 					"path": [
 						"api",
 						"v1",
 						"test_run",
 						"launch",
-						"20"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Get Test Runs",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "http://localhost:5001/api/v1/test_runs",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "5001",
-					"path": [
-						"api",
-						"v1",
-						"test_runs"
+						"1"
 					]
 				}
 			},
@@ -334,12 +321,12 @@
 					}
 				},
 				"url": {
-					"raw": "http://localhost:5001/api/v1/test_suite",
+					"raw": "http://localhost:5000/api/v1/test_suite",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "5001",
+					"port": "5000",
 					"path": [
 						"api",
 						"v1",
@@ -355,12 +342,12 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:5001/api/v1/test_suite/1",
+					"raw": "http://localhost:5000/api/v1/test_suite/1",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "5001",
+					"port": "5000",
 					"path": [
 						"api",
 						"v1",
@@ -377,12 +364,12 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:5001/api/v1/tests_suite_history/test_run/1",
+					"raw": "http://localhost:5000/api/v1/tests_suite_history/test_run/1",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "5001",
+					"port": "5000",
 					"path": [
 						"api",
 						"v1",
@@ -400,41 +387,20 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:5001/api/v1/tests_suite_history/test_status/3/test_run/1",
+					"raw": "http://localhost:5000/api/v1/tests_suite_history/test_status/1/test_run/1",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "5001",
+					"port": "5000",
 					"path": [
 						"api",
 						"v1",
 						"tests_suite_history",
 						"test_status",
-						"3",
+						"1",
 						"test_run",
 						"1"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Get Test Suites",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "http://localhost:5001/api/v1/test_suites",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "5001",
-					"path": [
-						"api",
-						"v1",
-						"test_suites"
 					]
 				}
 			},
@@ -462,12 +428,12 @@
 					}
 				},
 				"url": {
-					"raw": "http://localhost:5001/api/v1/test",
+					"raw": "http://localhost:5000/api/v1/test",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "5001",
+					"port": "5000",
 					"path": [
 						"api",
 						"v1",
@@ -483,12 +449,12 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:5001/api/v1/test/1",
+					"raw": "http://localhost:5000/api/v1/test/1",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "5001",
+					"port": "5000",
 					"path": [
 						"api",
 						"v1",
@@ -505,12 +471,12 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:5001/api/v1/tests_history/test_status/1",
+					"raw": "http://localhost:5000/api/v1/tests_history/test_status/1",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "5001",
+					"port": "5000",
 					"path": [
 						"api",
 						"v1",
@@ -528,12 +494,12 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:5001/api/v1/tests_history/test_status/1/test_run/2",
+					"raw": "http://localhost:5000/api/v1/tests_history/test_status/1/test_run/1",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "5001",
+					"port": "5000",
 					"path": [
 						"api",
 						"v1",
@@ -541,7 +507,7 @@
 						"test_status",
 						"1",
 						"test_run",
-						"2"
+						"1"
 					]
 				}
 			},
@@ -553,12 +519,12 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:5001/api/v1/tests_history/test_resolution/1",
+					"raw": "http://localhost:5000/api/v1/tests_history/test_resolution/1",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "5001",
+					"port": "5000",
 					"path": [
 						"api",
 						"v1",
@@ -576,18 +542,18 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:5001/api/v1/tests_history/test_suite/2",
+					"raw": "http://localhost:5000/api/v1/tests_history/test_suite/1",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "5001",
+					"port": "5000",
 					"path": [
 						"api",
 						"v1",
 						"tests_history",
 						"test_suite",
-						"2"
+						"1"
 					]
 				}
 			},
@@ -618,39 +584,48 @@
 					}
 				},
 				"url": {
-					"raw": "http://localhost:5001/api/v1/tests_history/test_run/1",
+					"raw": "http://localhost:5000/api/v1/tests_history/test_run/5",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "5001",
+					"port": "5000",
 					"path": [
 						"api",
 						"v1",
 						"tests_history",
 						"test_run",
-						"1"
+						"5"
 					]
 				}
 			},
 			"response": []
 		},
 		{
-			"name": "Get Tests",
+			"name": "Update Test History Resolution",
 			"request": {
-				"method": "GET",
+				"method": "PUT",
 				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"test_history_id\": 2,\n\t\"test_resolution\": \"Working as expected\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
 				"url": {
-					"raw": "http://localhost:5001/api/v1/tests",
+					"raw": "http://localhost:5000/api/v1/test_history_resolution",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "5001",
+					"port": "5000",
 					"path": [
 						"api",
 						"v1",
-						"tests"
+						"test_history_resolution"
 					]
 				}
 			},

--- a/app.py
+++ b/app.py
@@ -135,6 +135,30 @@ def create_launch():
 
     return resp
 
+
+@app.route("/api/v1/finish_launch", methods=["PUT"])
+def finish_launch():
+    params = request.get_json(force=True)
+    logger.info("/update_launch/%s", params)
+
+    failed_runs = crud.Read.test_runs_failed_by_launch_id(params.get("launch_id"))
+
+    if failed_runs:
+        launch_id = crud.Update.update_launch(
+            params.get("launch_id"), "Failed"
+        )
+    else:
+        launch_id = crud.Update.update_launch(
+            params.get("launch_id"), "Successful"
+        )
+
+    data = {"message": "Launch updated successfully", "id": launch_id}
+
+    resp = jsonify(data)
+    resp.status_code = 200
+
+    return resp
+
 @app.route("/api/v1/launch/<int:launch_id>", methods=["GET"])
 def get_launch(launch_id):
     logger.info("/launch/%i", launch_id)
@@ -485,6 +509,23 @@ def update_test_history():
 
     return resp
 
+@app.route("/api/v1/test_history_resolution", methods=["PUT"])
+def update_test_history_resolution():
+    params = request.get_json(force=True)
+    logger.info("/update_test_history_resolution/%s", params)
+
+    crud.Update.update_test_history_resolution(
+        params.get("test_history_id"),
+        params.get("test_resolution")
+    )
+
+    data = {"message": "Test history resolution updated successfully"}
+
+    resp = jsonify(data)
+    resp.status_code = 200
+
+    return resp
+
 
 @app.route("/api/v1/tests_suite_history/test_run/<int:test_run_id>", methods=["GET"])
 def get_tests_suite_history_by_test_run(test_run_id):
@@ -713,7 +754,6 @@ def get_tests_history_by_test_status_id(test_status_id):
                 {
                     "id": test_history.id,
                     "name": test_history.test.name,
-                    "data": test_history.data,
                     "start_datetime": test_history.start_datetime,
                     "end_datetime": test_history.end_datetime,
                     "duration": diff_dates(
@@ -747,7 +787,6 @@ def get_tests_history_by_test_resolution_id(test_resolution_id):
                 {
                     "id": test_history.id,
                     "name": test_history.test.name,
-                    "data": test_history.data,
                     "start_datetime": test_history.start_datetime,
                     "end_datetime": test_history.end_datetime,
                     "duration": diff_dates(
@@ -782,7 +821,6 @@ def get_tests_history_by_test_suite_id(test_suite_id):
                 {
                     "id": test_history.id,
                     "name": test.name,
-                    "data": test_history.data,
                     "start_datetime": test_history.start_datetime,
                     "end_datetime": test_history.end_datetime,
                     "duration": diff_dates(

--- a/data/crud.py
+++ b/data/crud.py
@@ -178,7 +178,7 @@ class Read:
     @staticmethod
     def launch_by_project_id(project_id):
         try:
-            launch = models.Launch.query.filter_by(project_id=project_id).all()
+            launch = models.Launch.query.filter_by(project_id=project_id).order_by(models.Launch.id.desc()).all()
         except exc.SQLAlchemyError as e:
             logger.error(e)
             db.session.rollback()
@@ -207,6 +207,17 @@ class Read:
             test_run = None
 
         return test_run
+
+    @staticmethod
+    def test_runs_failed_by_launch_id(launch_id):
+        try:
+            failed_runs = models.TestRun.query.filter_by(launch_id=launch_id, test_run_status_id=constants.Constants.test_run_status["Failed"]).all()
+        except exc.SQLAlchemyError as e:
+            logger.error(e)
+            db.session.rollback()
+            failed_runs = None
+
+        return failed_runs
 
     @staticmethod
     def test_suite_by_id(test_suite_id):
@@ -396,6 +407,15 @@ class Update:
         return test_history.id
 
     @staticmethod
+    def update_test_history_resolution(test_history_id, test_resolution):
+        test_history = db.session.query(models.TestHistory).get(test_history_id)
+        test_history.test_resolution_id = constants.Constants.test_resolution.get(test_resolution)
+
+        session_commit()
+
+        return test_history.id
+
+    @staticmethod
     def update_test_suite_history(
         test_suite_history_id, end_datetime, data, test_suite_status
     ):
@@ -424,3 +444,14 @@ class Update:
         session_commit()
 
         return test_run.id
+
+    @staticmethod
+    def update_launch(launch_id, launch_status):
+        launch = db.session.query(models.Launch).get(launch_id)
+        launch.launch_status_id = constants.Constants.launch_status.get(
+            launch_status
+        )
+
+        session_commit()
+
+        return launch.id


### PR DESCRIPTION
`/api/v1/finish_launch`

On this endpoint, Delta will automatically check if any of the test runs has failed, so the status will be set accordingly 

```
{
    "launch_id": <int>
}
```

`/api/v1/test_history_resolution`

This endpoint will populate `test_resolution` for the requested `test_history_id`

```
{
	"test_history_id": <int>,
	"test_resolution": "<string>"
}
```