### PR TITLE
Added CORS for Core Service endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,11 +5,13 @@ from logzero import logger
 from io import BytesIO
 from flask import Flask, request, jsonify, render_template, send_file
 from flask_sqlalchemy import SQLAlchemy
+from flask_cors import CORS
 
 
 app = Flask(__name__)
 app.config.from_object(os.environ["APP_SETTINGS"])
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+cors = CORS(app, resources={r"/api/*": {"origins": "*"}})
 db = SQLAlchemy(app)
 
 from data import crud
@@ -797,7 +799,7 @@ def get_tests_history_by_test_status_and_test_run_id(test_status_id, test_run_id
         test_suites = []
         test_suites_index = {}
         index = -1
-        
+
         test_run = {
             "test_run_id": tests_history[0][0].id,
             "launch_id": tests_history[0][0].launch.id,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,3 +35,4 @@ virtualenv==20.0.17
 Werkzeug==1.0.1
 wrapt==1.12.1
 zipp==3.1.0
+flask-cors==3.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ psycopg2-binary==2.8.5
 python-dateutil==2.8.1
 SQLAlchemy==1.3.16
 Werkzeug==1.0.1
+flask-cors==3.0.8


### PR DESCRIPTION
With this change, all the endpoints on `api/*`with integrate this header `Access-Control-Allow-Origin: *` which would allow the Frontend to make an asynchronous call to the Core service. The only drawback of this is that any other system could make these requests, which is not going to be solved until some authentication or CSRF measure is implemented.