### PR TITLE
Automatic db upgrade for dev mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN apk update && apk add libpq
 ADD . /app
 WORKDIR /app
 EXPOSE 5000
-CMD ["python3", "app.py"]
+CMD ["./start_dev.sh"]

--- a/start_dev.sh
+++ b/start_dev.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+python manage.py db upgrade
+python app.py


### PR DESCRIPTION
After updating, please run a docker-compose build to update the docker image, after that, there will be no need to run the upgrade command anymore