### PR TITLE
Adding data in resolution response, adding test stats in status endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -583,7 +583,11 @@ def update_test_history_resolution():
         params.get("test_history_id"), params.get("test_resolution")
     )
 
-    data = {"message": "Test history resolution updated successfully"}
+    data = {
+        "message": "Test history resolution updated successfully", 
+        "resolution": params.get("test_resolution"), 
+        "test_history_id": params.get("test_history_id")
+    }
 
     resp = jsonify(data)
     resp.status_code = 200
@@ -816,6 +820,12 @@ def get_tests_history_by_test_status_and_test_run_id(test_status_id, test_run_id
         for table in tests_history:
             test_suite_history = table[1]
             test_history = table[2]
+            total_count = table[3]
+            failed_count = table[4]
+            passed_count = table[5]
+            running_count = table[6]
+            incomplete_count = table[7]
+            skipped_count = table[8]
             if test_suites == [] or test_suite_history.id not in list(
                 test_suites_index.keys()
             ):
@@ -833,6 +843,12 @@ def get_tests_history_by_test_status_and_test_run_id(test_status_id, test_run_id
                             test_suite_history.end_datetime,
                         ),
                         "test_suite_status": test_suite_history.test_suite_status.name,
+                        "tests_total": total_count if total_count else 0,
+                        "tests_failed": failed_count if failed_count else 0,
+                        "tests_passed": passed_count if passed_count else 0,
+                        "tests_running": running_count if running_count else 0,
+                        "tests_incomplete": incomplete_count if incomplete_count else 0,
+                        "tests_skipped": skipped_count if skipped_count else 0,
                         "tests": [],
                     }
                 )

--- a/app.py
+++ b/app.py
@@ -579,14 +579,14 @@ def update_test_history_resolution():
     params = request.get_json(force=True)
     logger.info("/update_test_history_resolution/%s", params)
 
-    crud.Update.update_test_history_resolution(
+    test_history = crud.Update.update_test_history_resolution(
         params.get("test_history_id"), params.get("test_resolution")
     )
 
     data = {
         "message": "Test history resolution updated successfully", 
-        "resolution": params.get("test_resolution"), 
-        "test_history_id": params.get("test_history_id")
+        "resolution": test_history.test_resolution_id, 
+        "test_history_id": test_history.id 
     }
 
     resp = jsonify(data)

--- a/data/crud.py
+++ b/data/crud.py
@@ -508,9 +508,52 @@ class Read:
 
     @staticmethod
     def test_history_by_test_status_and_test_run_id(test_status_id, test_run_id):
+        
+        t_counts = TestCounts()
+        
         try:
             test_history = (
-                db.session.query(models.TestRun, models.TestSuiteHistory, models.TestHistory)
+                db.session.query(
+                    models.TestRun,
+                    models.TestSuiteHistory,
+                    models.TestHistory,
+                    t_counts.total_tests_by_test_suite_history_id.c.tests_count,
+                    t_counts.failed_tests_by_test_suite_history_id.c.failed_tests_count,
+                    t_counts.passed_tests_by_test_suite_history_id.c.passed_tests_count,
+                    t_counts.running_tests_by_test_suite_history_id.c.running_tests_count,
+                    t_counts.incomplete_tests_by_test_suite_history_id.c.incomplete_tests_count,
+                    t_counts.skipped_tests_by_test_suite_history_id.c.skipped_tests_count,
+                )
+                .outerjoin(
+                    t_counts.total_tests_by_test_suite_history_id,
+                    models.TestSuiteHistory.id
+                    == t_counts.total_tests_by_test_suite_history_id.c.test_suite_history_id,
+                )
+                .outerjoin(
+                    t_counts.failed_tests_by_test_suite_history_id,
+                    models.TestSuiteHistory.id
+                    == t_counts.failed_tests_by_test_suite_history_id.c.test_suite_history_id,
+                )
+                .outerjoin(
+                    t_counts.passed_tests_by_test_suite_history_id,
+                    models.TestSuiteHistory.id
+                    == t_counts.passed_tests_by_test_suite_history_id.c.test_suite_history_id,
+                )
+                .outerjoin(
+                    t_counts.running_tests_by_test_suite_history_id,
+                    models.TestSuiteHistory.id
+                    == t_counts.running_tests_by_test_suite_history_id.c.test_suite_history_id,
+                )
+                .outerjoin(
+                    t_counts.incomplete_tests_by_test_suite_history_id,
+                    models.TestSuiteHistory.id
+                    == t_counts.incomplete_tests_by_test_suite_history_id.c.test_suite_history_id,
+                )
+                .outerjoin(
+                    t_counts.skipped_tests_by_test_suite_history_id,
+                    models.TestSuiteHistory.id
+                    == t_counts.skipped_tests_by_test_suite_history_id.c.test_suite_history_id,
+                )
                 .filter(models.TestRun.id == models.TestSuiteHistory.test_run_id)
                 .filter(models.TestSuiteHistory.test_run_id == models.TestHistory.test_run_id)
                 .filter(models.TestSuiteHistory.id  == models.TestHistory.test_suite_history_id)
@@ -636,7 +679,7 @@ class Update:
 
         session_commit()
 
-        return test_history.id
+        return test_history
 
     @staticmethod
     def update_test_suite_history(


### PR DESCRIPTION
- I need this data in resolution response to try and fix that bug on the frontend
- adding stats to endpoint where tests can be retrieved by status, so it has all the same props as a normal full endpoint (makes sense to show how many tests failed on failed tests page)