### PR TITLE
Making status endpoint to accept array

### DIFF
--- a/app.py
+++ b/app.py
@@ -742,16 +742,16 @@ def get_tests_history_by_test_run(test_run_id):
 
 
 @app.route(
-    "/api/v1/tests_history/test_status/<int:test_status_id>/test_run/<int:test_run_id>",
+    "/api/v1/tests_history/test_status/<test_statuses_ids>/test_run/<int:test_run_id>",
     methods=["GET"],
 )
-def get_tests_history_by_test_status_and_test_run_id(test_status_id, test_run_id):
+def get_tests_history_by_test_status_and_test_run_id(test_statuses_ids, test_run_id):
     logger.info(
-        "/tests_history/test_status/%i/test_run/%i/", test_status_id, test_run_id
+        "/tests_history/test_status/%s/test_run/%i/", test_statuses_ids, test_run_id
     )
 
-    tests_history = crud.Read.test_history_by_test_status_and_test_run_id(
-        test_status_id=test_status_id, test_run_id=test_run_id
+    tests_history = crud.Read.test_history_by_array_of_test_statuses_and_test_run_id(
+        test_statuses_ids=test_statuses_ids, test_run_id=test_run_id
     )
 
     if tests_history:

--- a/data/crud.py
+++ b/data/crud.py
@@ -5,7 +5,7 @@ from logzero import logger
 from sqlalchemy import exc
 from sqlalchemy.sql import func
 from data.subqueries import TestCounts
-
+import re
 
 def session_commit():
     try:
@@ -496,8 +496,11 @@ class Read:
         return test_history
 
     @staticmethod
-    def test_history_by_test_status_and_test_run_id(test_status_id, test_run_id):
+    def test_history_by_array_of_test_statuses_and_test_run_id(test_statuses_ids, test_run_id):
 
+        array_of_statuses = re.findall('\d+', test_statuses_ids)  # getting all numbers from string
+        print ("Test statuses array: ", array_of_statuses) 
+        
         t_counts = TestCounts()
 
         try:
@@ -553,7 +556,7 @@ class Read:
                     == models.TestHistory.test_suite_history_id
                 )
                 .filter(models.TestRun.id == test_run_id)
-                .filter(models.TestHistory.test_status_id == test_status_id)
+                .filter(models.TestHistory.test_status_id.in_(array_of_statuses))
                 .all()
             )
         except exc.SQLAlchemyError as e:
@@ -562,7 +565,7 @@ class Read:
             test_history = None
 
         return test_history
-
+    
     @staticmethod
     def test_history_by_test_status_id(test_status_id):
         try:


### PR DESCRIPTION
Changing the exiting endpoint to accept a string.
My idea is to use it this way:
/api/v1/tests_history/test_status/**1+3+5**/test_run/123
so now accepting the string, extracting numbers from that string and putting it into an array. Then in the query just filtering IN that array of values.


@Jnegrier I am ready for your suggestions 🙈 