### PR TITLE
Adding test_run_data to tests_history/test_run/<id>

### DIFF
--- a/app.py
+++ b/app.py
@@ -674,6 +674,7 @@ def get_tests_history_by_test_run(test_run_id):
                 results[0][0].start_datetime, results[0][0].end_datetime
             ),
             "test_run_status": results[0][0].test_run_status.name,
+            "test_run_data": results[0][0].data,
         }
         for table in results:
             test_suite_history = table[1]


### PR DESCRIPTION
Forgot to add `test_run_data` to this endpoint, which is the main endpoint to get suites and test before applying any status filter