### PR TITLE
New endpoint for flaky tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -678,6 +678,7 @@ def get_tests_history_by_test_run(test_run_id):
             "test_run_id": results[0][0].id,
             "launch_id": results[0][0].launch.id,
             "project_id": results[0][0].launch.project.id,
+            "project_name": results[0][0].launch.project.name,
             "launch": results[0][0].launch.name,
             "test_type": results[0][0].test_type,
             "start_datetime": results[0][0].start_datetime,

--- a/app.py
+++ b/app.py
@@ -1056,6 +1056,45 @@ def get_test_history_by_test_id(test_id):
     return resp
 
 
+@app.route("/api/v1/check_if_more_than_five_failed_in_the_last_ten_runs/test_id/<int:test_id>", methods=["GET"])
+def check_if_more_than_five_failed_in_the_last_ten_runs(test_id):
+    logger.info("/tests_history_by_test_id/%i", test_id)
+    status = 200
+
+    results = crud.Read.test_history_by_test_id(test_id)
+
+    if results:
+        data = []
+        for test_history in results:
+            if test_history.test_status.name == 'Failed':
+                data.append(
+                    {
+                        "test_history_id": test_history.id,
+                        "start_datetime": test_history.start_datetime,
+                        "end_datetime": test_history.end_datetime,
+                        "duration": diff_dates(
+                            test_history.start_datetime, test_history.end_datetime
+                        ),
+                        "status": test_history.test_status.name,
+                        "resolution": test_history.test_resolution.id,
+                        "trace": test_history.trace,
+                        "message": test_history.message,
+                        "error_type": test_history.error_type,
+                        "media": test_history.media,
+                    }
+                )
+    else:
+        data = {"message": "No history was found"}
+        status = 204
+
+    if len(data) >= 5:
+        resp = "flaky"
+    else:
+        resp = "stable"
+        
+    return resp
+
+
 @app.route("/api/v1/get_file/<int:media_id>", methods=["GET"])
 def get_file_by_media_id(media_id):
     logger.info("/get_file_by_media_id/%i", media_id)

--- a/app.py
+++ b/app.py
@@ -1070,17 +1070,6 @@ def check_if_more_than_five_failed_in_the_last_ten_runs(test_id):
                 data.append(
                     {
                         "test_history_id": test_history.id,
-                        "start_datetime": test_history.start_datetime,
-                        "end_datetime": test_history.end_datetime,
-                        "duration": diff_dates(
-                            test_history.start_datetime, test_history.end_datetime
-                        ),
-                        "status": test_history.test_status.name,
-                        "resolution": test_history.test_resolution.id,
-                        "trace": test_history.trace,
-                        "message": test_history.message,
-                        "error_type": test_history.error_type,
-                        "media": test_history.media,
                     }
                 )
     else:
@@ -1088,9 +1077,9 @@ def check_if_more_than_five_failed_in_the_last_ten_runs(test_id):
         status = 204
 
     if len(data) >= 5:
-        resp = "flaky"
+        resp = jsonify({"message": "flaky"})
     else:
-        resp = "stable"
+        resp = jsonify({"message": "stable"})
         
     return resp
 

--- a/data/crud.py
+++ b/data/crud.py
@@ -662,7 +662,7 @@ class Read:
                     != constants.Constants.test_status["Running"],
                 )
                 .order_by(models.TestHistory.end_datetime.desc())
-                .limit(5)
+                .limit(10)
                 .all()
             )
         except exc.SQLAlchemyError as e:
@@ -671,7 +671,6 @@ class Read:
             test_history = None
 
         return test_history
-
 
 class Update:
     @staticmethod


### PR DESCRIPTION
Endpoint that gets last 10 test_histories, then get's only those where status = "Failed", then checks if the number is bigger than five - marks it as flaky.
Frontend idea: https://github.com/delta-reporter/delta-frontend/pull/45