### PR TITLE
Adding limit to launches endpoint

### DIFF
--- a/data/crud.py
+++ b/data/crud.py
@@ -274,6 +274,7 @@ class Read:
                 .filter(models.TestRun.launch_id == models.Launch.id)
                 .filter(models.Launch.project_id == project_id)
                 .order_by(models.Launch.id.desc())
+                .limit(100)
                 .all()
             )
         except exc.SQLAlchemyError as e:


### PR DESCRIPTION
Limiting number of results on the launches endpoint, cause some Projects became too heavy to load.
One page contains roughly 20 launches, so limiting it to 100 (5 pages to view back should be enough?)