### PR TITLE
Adding endpoint to get tests failing the most

### DIFF
--- a/app.py
+++ b/app.py
@@ -1374,6 +1374,39 @@ def get_weekly_stats(project_id):
     return resp
 
 
+@app.route("/api/v1/most_failed_tests/<int:project_id>", methods=["GET"])
+def most_failed_tests_by_project(project_id):
+    logger.info("/most_failed_tests/%s", project_id)
+
+    failed_tests_data = crud.Read.tests_failing_the_most(project_id)
+
+    data = []
+
+    for (
+        test_id,
+        name,
+        is_flaky,
+        test_type,
+        test_suite,
+        failed_count
+    ) in failed_tests_data:
+        data.append(
+            {
+                "id": test_id,
+                "name": name,
+                "is_flaky": is_flaky,
+                "test_type": test_type,
+                "test_suite": test_suite,
+                "failed_count": none_checker(failed_count)
+            }
+        )
+
+    resp = jsonify(data)
+    resp.status_code = 200
+
+    return resp
+
+
 @app.errorhandler(404)
 def notfound(error):
     data = {"message": "The endpoint requested was not found"}

--- a/data/crud.py
+++ b/data/crud.py
@@ -821,7 +821,7 @@ class Read:
     def tests_failing_the_most(project_id):
 
         def week_date():
-            dat = date.today() - timedelta(days=60)
+            dat = date.today() - timedelta(days=7)
             return dat.isoformat()
 
         try:

--- a/data/crud.py
+++ b/data/crud.py
@@ -1,3 +1,4 @@
+from sqlalchemy.sql.expression import desc
 import models
 import datetime
 from app import db
@@ -815,27 +816,48 @@ class Read:
 
         return week_stats
 
-    @staticmethod
-    def tests_distribution_by_launch(project_id):
-        try:
-            smart_links = models.SmartLinks.query.filter_by(project_id=project_id).all()
-        except exc.SQLAlchemyError as e:
-            logger.error(e)
-            db.session.rollback()
-            smart_links = None
-
-        return smart_links
 
     @staticmethod
     def tests_failing_the_most(project_id):
+
+        def week_date():
+            dat = date.today() - timedelta(days=60)
+            return dat.isoformat()
+
         try:
-            smart_links = models.SmartLinks.query.filter_by(project_id=project_id).all()
+            failed_stats = db.session.query(
+                models.MotherTest.id,
+                models.MotherTest.name,
+                models.MotherTest.is_flaky,
+                models.TestSuite.test_type,
+                models.TestSuite.name,
+                func.count("*").label("tests_count")
+            ).filter(
+                models.Test.start_datetime <= date.today().isoformat()
+            ).filter(
+                models.Test.start_datetime >= week_date()
+            ).filter(
+                models.Test.test_status_id == 1
+            ).filter(
+                models.MotherTest.id == models.Test.mother_test_id
+            ).filter(
+                models.TestSuite.id == models.MotherTest.test_suite_id
+            ).filter(
+                models.TestSuite.project_id == project_id
+            ).group_by(
+                models.MotherTest.id,
+                models.TestSuite.id
+            ).order_by(
+                desc('tests_count')
+            ).limit(
+                12
+            ).all()
         except exc.SQLAlchemyError as e:
             logger.error(e)
             db.session.rollback()
-            smart_links = None
+            failed_stats = None
 
-        return smart_links
+        return failed_stats
 
 
 class Update:


### PR DESCRIPTION
Created new endpoint on `/api/v1/most_failed_tests/<project_id>`

Response example:

```
[
  {
    "failed_count": 6, 
    "id": 870, 
    "is_flaky": true, 
    "name": "testLogin", 
    "test_suite": "EndToEndTests:EndToEndTest\\LoginTest", 
    "test_type": "Unit Tests"
  }, 
  {
    "failed_count": 6, 
    "id": 873, 
    "is_flaky": true, 
    "name": "testOnboard", 
    "test_suite": "EndToEndTests:EndToEndTests\\OnboardingTest", 
    "test_type": "Unit Tests"
  }, 
  {...
```